### PR TITLE
fix(infra): fix Splunk startup crash and Cribl HEC timing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
     volumes:
       - splunk-data:/opt/splunk/var
       - ./splunk/default.yml:/tmp/defaults/default.yml:ro
-      - ./splunk/apps/blue_team_lab:/opt/splunk/etc/apps/blue_team_lab:ro
+      - ./splunk/apps/blue_team_lab:/opt/splunk/etc/apps/blue_team_lab
     healthcheck:
       test: ["CMD", "curl", "-sf", "https://localhost:8089/services/server/health", "-k", "-u", "admin:BlueTeamLab1!"]
       interval: 15s


### PR DESCRIPTION
## Summary

- **Splunk crash**: Removed `:ro` from `blue_team_lab` app volume mount — Splunk's ansible startup runs `chown` on all app dirs, which fails on read-only mounts (exit code 2)
- **Cribl HEC timing**: Refactored simulator connectivity into separate check functions. Simulator now gives Cribl HEC up to 60s extra to come online after the health endpoint is ready, instead of immediately falling back to direct delivery on first failure

Found during `./setup.sh --full` test.

## Test plan
- [ ] `./setup.sh --full` — Splunk starts successfully
- [ ] `./setup.sh --full` — Simulator routes through Cribl (not direct)
- [ ] `./setup.sh --elastic` — Simulator falls back to direct ES delivery (no Cribl)
- [ ] Data appears in both `sim-baseline` and `sim-attack`

Generated with [Claude Code](https://claude.com/claude-code)