### PR TITLE
fix(claude_llm): Windows UTF-8 encoding for subprocess

### DIFF
--- a/autonomous/orchestration/claude_llm.py
+++ b/autonomous/orchestration/claude_llm.py
@@ -169,11 +169,13 @@ def ask(
             cmd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout_seconds,
             cwd=str(Path(__file__).resolve().parent.parent.parent),  # repo root
         )
 
-        response_text = result.stdout.strip()
+        response_text = (result.stdout or "").strip()
 
         if result.returncode != 0:
             error_text = result.stderr.strip()[:500] if result.stderr else "Unknown error"


### PR DESCRIPTION
## Summary

Fixes `UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d` when Claude CLI returns UTF-8 output (em dashes, etc.) on Windows.

## Changes

- Add `encoding="utf-8"` + `errors="replace"` to `subprocess.run` in `claude_llm.ask()`
- Guard against `None` stdout: `(result.stdout or "").strip()`

## Bug found during

Intel agent web search test — Claude CLI returned UTF-8 content but Windows `subprocess.run(text=True)` defaults to `cp1252`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)