### PR TITLE
fix(claude_llm): route Bash(curl:*) to --allowed-tools

### DIFF
--- a/autonomous/orchestration/claude_llm.py
+++ b/autonomous/orchestration/claude_llm.py
@@ -156,7 +156,15 @@ def ask(
         if not allowed_tools:
             cmd += ["--tools", ""]  # Disable all tools — pure reasoning
         else:
-            cmd += ["--tools", ",".join(allowed_tools)]
+            # --tools takes plain names: "Bash,Edit,Read"
+            # --allowed-tools takes restriction patterns: "Bash(curl:*) Edit"
+            # Split: patterns with parens go to --allowed-tools, plain go to --tools
+            plain = [t for t in allowed_tools if "(" not in t]
+            restricted = [t for t in allowed_tools if "(" in t]
+            if plain:
+                cmd += ["--tools", ",".join(plain)]
+            if restricted:
+                cmd += ["--allowed-tools"] + restricted
 
     if max_turns:
         cmd += ["--max-turns", str(max_turns)]


### PR DESCRIPTION
## Summary

Follow-up to PR #25. The `Bash(curl:*)` restriction pattern was being passed to `--tools` which only accepts plain names. Claude CLI has two separate flags:

- `--tools "Bash,Edit,Read"` — plain built-in tool names
- `--allowed-tools "Bash(curl:*)"` — restriction patterns

## Fix

Auto-detect patterns with parentheses and route them to `--allowed-tools`.

## Result

Command now correctly builds as:
```
claude --print --model sonnet --allowed-tools Bash(curl:*)
```

Instead of the broken:
```
claude --print --model sonnet --tools Bash(curl:*)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)