### PR TITLE
fix(ci): add pull-requests:write permission to security gate

### DIFF
--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -9,6 +9,10 @@ concurrency:
   group: security-gate-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   security-review:
     runs-on: ubuntu-latest
@@ -18,7 +22,8 @@ jobs:
       startsWith(github.head_ref, 'agent/') ||
       startsWith(github.head_ref, 'orchestration/') ||
       startsWith(github.head_ref, 'detection/') ||
-      startsWith(github.head_ref, 'tuning/')
+      startsWith(github.head_ref, 'tuning/') ||
+      startsWith(github.head_ref, 'infra/')
 
     steps:
       - name: Checkout PR branch


### PR DESCRIPTION
## Summary\n- Security agent gets 403 when posting PR review comments — default GITHUB_TOKEN is read-only for PRs\n- Added `permissions: pull-requests: write` to the workflow\n- Also added `infra/` branch prefix to trigger filter\n\n## Test plan\n- [ ] Next agent PR should show security review comment posted successfully\n\n---\n*Generated with [Claude Code](https://claude.com/claude-code)*