### PR TITLE
[Infra] Ignore .claude/ directories at any depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,6 @@ simulator/data/
 autonomous/budget-log.jsonl
 autonomous/security/audit-log.jsonl
 
-# Claude Code local settings
-.claude/settings.local.json
-.claude/projects/
+# Claude Code local settings (any depth)
+**/.claude/
+.claude/


### PR DESCRIPTION
## Summary
- Broadens `.claude/` gitignore entry to `**/.claude/` so Claude Code session state is ignored at any directory depth (e.g. `autonomous/.claude/settings.local.json`)
- Prevents user-specific local permission grants and paths from leaking into the repo

## Test plan
- [ ] Verify `git status` shows no untracked files after merging
- [ ] Confirm `autonomous/.claude/` remains untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)