### PR TITLE
[Fix] Allow claude -p calls from within Claude Code session

### DIFF
--- a/autonomous/orchestration/claude_llm.py
+++ b/autonomous/orchestration/claude_llm.py
@@ -79,10 +79,6 @@ def is_available() -> bool:
     if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"):
         return False
 
-    # Nested session detection — can't invoke claude -p from inside Claude Code
-    if os.environ.get("CLAUDECODE"):
-        return False
-
     cli = _find_claude_cli()
     if not cli:
         return False


### PR DESCRIPTION
## Summary
- Removes the `CLAUDECODE` env var guard from `claude_llm.is_available()`
- The guard blocked all `claude -p` subprocess calls when agents were run from inside a Claude Code session
- Verified that `--print --no-session-persistence` mode works correctly as a nested subprocess — no conflicts
- CI guard (GitHub Actions / `GITHUB_ACTIONS` env var) is kept since those environments have no OAuth session

## Impact
Intel agent link analysis, red-team scenario generation, and blue-team rule authoring will now work when agents are invoked via Bash from within Claude Code, rather than silently skipping with "Claude CLI not available".

## Test plan
- [ ] Run intel agent and confirm link analysis executes (no "Claude CLI not available" message)
- [ ] Confirm CI workflows still skip claude -p correctly (GITHUB_ACTIONS guard intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)