### PR TITLE
fix(blue-team): fix 6 bugs blocking blue team agent pipeline run

### DIFF
--- a/autonomous/detection-requests/t1047.yml
+++ b/autonomous/detection-requests/t1047.yml
@@ -5,7 +5,7 @@ priority: high
 requested_by: intel
 requested_date: '2026-03-21T13:04:56Z'
 intel_report: threat-intel/fawkes/fawkes-ttp-mapping.md
-scenario_file: simulator\scenarios\t1047.json
+scenario_file: simulator/scenarios/t1047.json
 sigma_rule: ''
 deployed_date: ''
 last_quality_review: ''

--- a/autonomous/detection-requests/t1049.yml
+++ b/autonomous/detection-requests/t1049.yml
@@ -5,7 +5,7 @@ priority: high
 requested_by: intel
 requested_date: '2026-03-21T13:04:56Z'
 intel_report: threat-intel/fawkes/fawkes-ttp-mapping.md
-scenario_file: simulator\scenarios\t1049.json
+scenario_file: simulator/scenarios/t1049.json
 sigma_rule: ''
 deployed_date: ''
 last_quality_review: ''

--- a/autonomous/detection-requests/t1053_003.yml
+++ b/autonomous/detection-requests/t1053_003.yml
@@ -5,7 +5,7 @@ priority: high
 requested_by: intel
 requested_date: '2026-03-21T13:04:56Z'
 intel_report: threat-intel/fawkes/fawkes-ttp-mapping.md
-scenario_file: simulator\scenarios\t1053_003.json
+scenario_file: simulator/scenarios/t1053_003.json
 sigma_rule: ''
 deployed_date: ''
 last_quality_review: ''

--- a/autonomous/detection-requests/t1055_012.yml
+++ b/autonomous/detection-requests/t1055_012.yml
@@ -5,7 +5,7 @@ priority: high
 requested_by: intel
 requested_date: '2026-03-21T13:04:56Z'
 intel_report: threat-intel/fawkes/fawkes-ttp-mapping.md
-scenario_file: simulator\scenarios\t1055_012.json
+scenario_file: simulator/scenarios/t1055_012.json
 sigma_rule: ''
 deployed_date: ''
 last_quality_review: ''

--- a/autonomous/detection-requests/t1055_013.yml
+++ b/autonomous/detection-requests/t1055_013.yml
@@ -5,7 +5,7 @@ priority: high
 requested_by: intel
 requested_date: '2026-03-21T13:04:56Z'
 intel_report: threat-intel/fawkes/fawkes-ttp-mapping.md
-scenario_file: simulator\scenarios\t1055_013.json
+scenario_file: simulator/scenarios/t1055_013.json
 sigma_rule: ''
 deployed_date: ''
 last_quality_review: ''

--- a/autonomous/detection-requests/t1055_015.yml
+++ b/autonomous/detection-requests/t1055_015.yml
@@ -5,7 +5,7 @@ priority: high
 requested_by: intel
 requested_date: '2026-03-21T13:04:56Z'
 intel_report: threat-intel/fawkes/fawkes-ttp-mapping.md
-scenario_file: simulator\scenarios\t1055_015.json
+scenario_file: simulator/scenarios/t1055_015.json
 sigma_rule: ''
 deployed_date: ''
 last_quality_review: ''

--- a/autonomous/detection-requests/t1056_001.yml
+++ b/autonomous/detection-requests/t1056_001.yml
@@ -5,7 +5,7 @@ priority: high
 requested_by: intel
 requested_date: '2026-03-21T13:04:56Z'
 intel_report: threat-intel/fawkes/fawkes-ttp-mapping.md
-scenario_file: simulator\scenarios\t1056_001.json
+scenario_file: simulator/scenarios/t1056_001.json
 sigma_rule: ''
 deployed_date: ''
 last_quality_review: ''

--- a/autonomous/detection-requests/t1057.yml
+++ b/autonomous/detection-requests/t1057.yml
@@ -5,7 +5,7 @@ priority: high
 requested_by: intel
 requested_date: '2026-03-21T13:04:56Z'
 intel_report: threat-intel/fawkes/fawkes-ttp-mapping.md
-scenario_file: simulator\scenarios\t1057.json
+scenario_file: simulator/scenarios/t1057.json
 sigma_rule: ''
 deployed_date: ''
 last_quality_review: ''

--- a/autonomous/detection-requests/t1068.yml
+++ b/autonomous/detection-requests/t1068.yml
@@ -5,7 +5,7 @@ priority: high
 requested_by: intel
 requested_date: '2026-03-21T13:04:55Z'
 intel_report: threat-intel\reports\2026-03-21-apache-activemq-exploit-leads-to-lockbit-ransomwar.yml
-scenario_file: simulator\scenarios\t1068.json
+scenario_file: simulator/scenarios/t1068.json
 sigma_rule: ''
 deployed_date: ''
 last_quality_review: ''

--- a/autonomous/detection-requests/t1070_006.yml
+++ b/autonomous/detection-requests/t1070_006.yml
@@ -5,7 +5,7 @@ priority: high
 requested_by: intel
 requested_date: '2026-03-21T13:04:56Z'
 intel_report: threat-intel/fawkes/fawkes-ttp-mapping.md
-scenario_file: simulator\scenarios\t1070_006.json
+scenario_file: simulator/scenarios/t1070_006.json
 sigma_rule: ''
 deployed_date: ''
 last_quality_review: ''

--- a/autonomous/orchestration/agents/blue_team_agent.py
+++ b/autonomous/orchestration/agents/blue_team_agent.py
@@ -40,8 +40,11 @@ MAX_TUNE_RETRIES = 2  # Max attempts to refine a rule when F1 < threshold
 # Map MITRE technique prefixes to tactic directories
 TECHNIQUE_TACTIC_MAP = {
     "T1055": "privilege_escalation",
+    "T1068": "privilege_escalation",
     "T1134": "credential_access",
     "T1059": "execution",
+    "T1047": "execution",
+    "T1569": "execution",
     "T1053": "persistence",
     "T1547": "persistence",
     "T1543": "persistence",
@@ -51,15 +54,27 @@ TECHNIQUE_TACTIC_MAP = {
     "T1197": "defense_evasion",
     "T1071": "command_and_control",
     "T1219": "command_and_control",
+    "T1090": "command_and_control",
     "T1078": "initial_access",
     "T1566": "initial_access",
+    "T1133": "initial_access",
     "T1087": "discovery",
-    "T1047": "execution",
-    "T1003": "credential_access",
-    "T1490": "impact",
-    "T1569": "execution",
     "T1046": "discovery",
+    "T1049": "discovery",
+    "T1057": "discovery",
     "T1083": "discovery",
+    "T1518": "discovery",
+    "T1003": "credential_access",
+    "T1056": "collection",
+    "T1113": "collection",
+    "T1115": "collection",
+    "T1560": "collection",
+    "T1490": "impact",
+    "T1486": "impact",
+    "T1489": "impact",
+    "T1110": "credential_access",
+    "T1021": "lateral_movement",
+    "T1105": "command_and_control",
 }
 
 
@@ -93,6 +108,8 @@ SYSMON_CATEGORIES = {
 
 def load_scenario(scenario_path: str) -> dict | None:
     """Load a scenario JSON file."""
+    # Normalize path separators — YAML files written on Windows may contain backslashes
+    scenario_path = scenario_path.replace("\\", "/")
     full_path = REPO_ROOT / scenario_path
     if not full_path.exists():
         return None
@@ -514,7 +531,7 @@ def assess_quality(metrics: dict) -> str:
 
     if f1 >= AUTO_DEPLOY_THRESHOLD and fp_rate <= MAX_FP_RATE_AUTO_DEPLOY:
         return "auto_deploy"
-    elif f1 >= 0.70:
+    elif f1 >= 0.75:
         return "human_review"
     else:
         return "needs_rework"
@@ -586,6 +603,8 @@ def author_and_validate(request: dict, state_manager: StateManager, run_id: str)
 
     # Transpile
     lucene, spl = transpile_sigma(rule_path)
+    lucene_path = None
+    spl_path = None
     if lucene:
         lucene_path, spl_path = save_compiled(tactic, tid_under, lucene, spl)
         print(f"    [blue-team] Transpiled: Lucene ({len(lucene)} chars), SPL ({len(spl)} chars)")
@@ -600,8 +619,8 @@ def author_and_validate(request: dict, state_manager: StateManager, run_id: str)
     state_manager.update(
         tid, agent=AGENT_NAME,
         sigma_rule=str(rule_path.relative_to(REPO_ROOT)),
-        compiled_lucene=str(lucene_path.relative_to(REPO_ROOT)) if lucene else "",
-        compiled_spl=str(spl_path.relative_to(REPO_ROOT)) if spl else "",
+        compiled_lucene=str(lucene_path.relative_to(REPO_ROOT)) if lucene_path else "",
+        compiled_spl=str(spl_path.relative_to(REPO_ROOT)) if spl_path else "",
         mitre_tactic=tactic,
     )
 
@@ -966,5 +985,6 @@ def run(state_manager: StateManager) -> dict:
         "detections_validated": validated,
         "detections_deploy_eligible": deploy_eligible,
         "detections_needs_rework": needs_rework,
+        "detections_reviewed": authored,  # agent_runner budget tracking key
         "results": results,
     }

--- a/autonomous/orchestration/agents/red_team_agent.py
+++ b/autonomous/orchestration/agents/red_team_agent.py
@@ -938,8 +938,8 @@ def run(state_manager: StateManager) -> dict:
         print(f"    [red-team] Saved: {path.name} "
               f"({n_attack} attack, {n_benign} benign events)")
 
-        # Update detection request with scenario path
-        rel_path = str(path.relative_to(REPO_ROOT))
+        # Update detection request with scenario path (always use POSIX separators)
+        rel_path = path.relative_to(REPO_ROOT).as_posix()
         state_manager.update(
             tid, agent=AGENT_NAME,
             scenario_file=rel_path,


### PR DESCRIPTION
Critical (blocking):
- Fix Windows backslash paths in all 10 SCENARIO_BUILT detection requests (simulator\scenarios\*.json -> simulator/scenarios/*.json) Agent would fail to load any scenario, producing 0 authored detections.
- Fix red_team_agent: use .as_posix() instead of str() for scenario_file paths to prevent recurrence on any OS

Logic fixes:
- Fix assess_quality() threshold: F1 >= 0.70 -> F1 >= 0.75 to match CLAUDE.md spec ("F1 >= 0.75 for validated")
- Fix spl_path potential NameError: initialize lucene_path/spl_path = None before conditional; guard with 'if lucene_path/spl_path' not string value. Was a NameError risk when SPL transpile succeeds but Lucene fails.

Completeness fixes:
- Add 15 missing entries to TECHNIQUE_TACTIC_MAP: T1049/T1057/T1518 ->
  discovery, T1056/T1113/T1115/T1560 -> collection, T1068 -> privilege_escalation, T1090/T1105 -> c2, T1486/T1489/T1110 -> impact/ credential_access, T1021/T1133 -> lateral_movement/initial_access
- Add defensive backslash normalization in load_scenario()
- Add detections_reviewed key to run() return dict for agent_runner budget tracking (was falling through to default of 1 instead of actual count)

https://claude.ai/code/session_019XLq9d8yM2i7WBnNajXxcY