### PR TITLE
[Quality] Rule quality remediation - ECS fields, logsource, severity

### DIFF
--- a/detections/credential_access/t1003_001.yml
+++ b/detections/credential_access/t1003_001.yml
@@ -17,6 +17,7 @@ tags:
   - attack.credential_access
   - attack.t1003.001
 logsource:
+  category: process_access
   product: windows
 detection:
   selection_process_access:

--- a/detections/defense_evasion/t1027_001.yml
+++ b/detections/defense_evasion/t1027_001.yml
@@ -20,6 +20,7 @@ tags:
   - attack.defense_evasion
   - attack.t1027.001
 logsource:
+  category: process_creation
   product: windows
 detection:
   selection_process_creation:

--- a/detections/discovery/t1046.yml
+++ b/detections/discovery/t1046.yml
@@ -49,4 +49,4 @@ falsepositives:
     - Legitimate network scanning tools deployed to non-standard locations by IT teams
     - Vulnerability scanners running from temporary extraction directories
     - Software installers performing network checks during setup
-level: high
+level: medium

--- a/detections/execution/t1021_001.yml
+++ b/detections/execution/t1021_001.yml
@@ -12,6 +12,7 @@ tags:
     - attack.lateral_movement
     - attack.t1021.001
 logsource:
+    category: process_creation
     product: windows
 detection:
     selection_process:

--- a/detections/execution/t1059_003.yml
+++ b/detections/execution/t1059_003.yml
@@ -24,12 +24,12 @@ logsource:
   product: windows
 detection:
   selection_cmd:
-    Image|endswith: '\cmd.exe'
+    process.executable|endswith: '\cmd.exe'
   selection_chained_recon:
-    CommandLine|contains|all:
+    process.command_line|contains|all:
       - '/c'
       - '&'
-    CommandLine|contains:
+    process.command_line|contains:
       - 'whoami'
       - 'net user'
       - 'net localgroup'
@@ -43,7 +43,7 @@ detection:
       - 'reg query'
       - 'wmic'
   selection_suspicious_parent:
-    ParentImage|contains:
+    process.parent.executable|contains:
       - '\ProgramData\'
       - '\AppData\'
       - '\Temp\'
@@ -52,26 +52,26 @@ detection:
       - '\Downloads\'
       - '\Recycle'
   filter_programfiles:
-    ParentImage|startswith:
+    process.parent.executable|startswith:
       - 'C:\Program Files\'
       - 'C:\Program Files (x86)\'
   filter_windows_system:
-    ParentImage|startswith:
+    process.parent.executable|startswith:
       - 'C:\Windows\System32\'
       - 'C:\Windows\SysWOW64\'
       - 'C:\Windows\explorer.exe'
   filter_known_tools:
-    ParentImage|endswith:
+    process.parent.executable|endswith:
       - '\explorer.exe'
       - '\msiexec.exe'
       - '\services.exe'
   condition: selection_cmd and ((selection_chained_recon and not filter_programfiles) or (selection_suspicious_parent and not filter_windows_system and not filter_known_tools))
 fields:
-  - CommandLine
-  - ParentImage
-  - ParentCommandLine
-  - User
-  - Image
+  - process.command_line
+  - process.parent.executable
+  - process.parent.command_line
+  - user.name
+  - process.executable
 falsepositives:
   - Legitimate IT administration scripts running chained commands from Program Files
   - Software installers using cmd.exe for post-install configuration from temp directories

--- a/detections/execution/t1082.yml
+++ b/detections/execution/t1082.yml
@@ -20,33 +20,33 @@ logsource:
   product: windows
 detection:
   selection_shell:
-    Image|endswith: '\cmd.exe'
-    CommandLine|contains|all:
+    process.executable|endswith: '\cmd.exe'
+    process.command_line|contains|all:
       - '/c'
       - 'systeminfo'
-    CommandLine|contains:
+    process.command_line|contains:
       - 'whoami'
       - 'hostname'
       - 'ipconfig'
       - 'net config'
       - 'wmic os'
   filter_legitimate_parents:
-    ParentImage|startswith:
+    process.parent.executable|startswith:
       - 'C:\Program Files\'
       - 'C:\Program Files (x86)\'
       - 'C:\Windows\System32\'
       - 'C:\Windows\SysWOW64\'
       - 'C:\ProgramData\Microsoft\Windows Defender\'
   filter_system_account:
-    User|contains: 'SYSTEM'
+    user.name|contains: 'SYSTEM'
   condition: selection_shell and not filter_legitimate_parents and not filter_system_account
 fields:
-  - CommandLine
-  - ParentImage
-  - ParentCommandLine
-  - User
+  - process.command_line
+  - process.parent.executable
+  - process.parent.command_line
+  - user.name
   - host.name
 falsepositives:
   - System administrators running chained discovery commands from custom scripts in non-standard directories
   - Third-party monitoring or inventory tools installed outside Program Files
-level: high
+level: medium

--- a/detections/execution/t1190.yml
+++ b/detections/execution/t1190.yml
@@ -23,7 +23,7 @@ logsource:
   product: windows
 detection:
   selection_parent:
-    ParentImage|endswith:
+    process.parent.executable|endswith:
       - '\w3wp.exe'
       - '\httpd.exe'
       - '\nginx.exe'
@@ -32,7 +32,7 @@ detection:
       - '\java.exe'
       - '\node.exe'
   selection_child_path:
-    Image|contains:
+    process.executable|contains:
       - '\ProgramData\'
       - '\Temp\'
       - '\tmp\'
@@ -43,22 +43,22 @@ detection:
       - '\Windows\Tasks\'
       - '\perflogs\'
   filter_legitimate_iis:
-    Image|endswith:
+    process.executable|endswith:
       - '\csc.exe'
       - '\conhost.exe'
       - '\WerFault.exe'
-    ParentImage|endswith: '\w3wp.exe'
+    process.parent.executable|endswith: '\w3wp.exe'
   filter_dotnet_compilation:
-    Image|endswith:
+    process.executable|endswith:
       - '\vbc.exe'
       - '\csc.exe'
-    Image|startswith: 'C:\Windows\Microsoft.NET\'
+    process.executable|startswith: 'C:\Windows\Microsoft.NET\'
   filter_azure_guest_agent:
-    Image|startswith: 'C:\WindowsAzure\'
-    ParentImage|endswith: '\services.exe'
+    process.executable|startswith: 'C:\WindowsAzure\'
+    process.parent.executable|endswith: '\services.exe'
   condition: selection_parent and selection_child_path and not 1 of filter_*
 falsepositives:
   - Legitimate web application frameworks that compile code at runtime via csc.exe or vbc.exe
   - Web-deployed update utilities that stage binaries in ProgramData before installation
   - Custom IIS modules that spawn helper processes in non-standard paths
-level: high
+level: critical

--- a/detections/execution/t1204_002.yml
+++ b/detections/execution/t1204_002.yml
@@ -22,7 +22,7 @@ logsource:
   product: windows
 detection:
   selection_parent:
-    ParentImage|endswith:
+    process.parent.executable|endswith:
       - '\OUTLOOK.EXE'
       - '\WINWORD.EXE'
       - '\EXCEL.EXE'
@@ -32,7 +32,7 @@ detection:
       - '\ONENOTE.EXE'
       - '\ONENOTEM.EXE'
   selection_child_path:
-    Image|contains:
+    process.executable|contains:
       - '\ProgramData\'
       - '\AppData\Local\Temp\'
       - '\AppData\Roaming\'
@@ -40,12 +40,12 @@ detection:
       - '\Downloads\'
       - '\Temp\'
   filter_system_account:
-    User|contains:
+    user.name|contains:
       - 'SYSTEM'
       - 'LOCAL SERVICE'
       - 'NETWORK SERVICE'
   filter_legitimate_children:
-    Image|endswith:
+    process.executable|endswith:
       - '\MicrosoftEdgeUpdate.exe'
       - '\Teams.exe'
       - '\OneDrive.exe'
@@ -53,14 +53,14 @@ detection:
       - '\ai.exe'
       - '\splwow64.exe'
   filter_microsoft_signed_paths:
-    Image|contains:
+    process.executable|contains:
       - '\ProgramData\Microsoft\'
   condition: selection_parent and selection_child_path and not filter_system_account and not filter_legitimate_children and not filter_microsoft_signed_paths
 fields:
-  - Image
-  - ParentImage
-  - CommandLine
-  - User
+  - process.executable
+  - process.parent.executable
+  - process.command_line
+  - user.name
   - host.name
   - process.hash.sha256
 falsepositives:

--- a/detections/execution/t1486.yml
+++ b/detections/execution/t1486.yml
@@ -89,4 +89,4 @@ falsepositives:
   - Security tools that quarantine files with custom extensions
   - Backup software writing encrypted archives to temp paths
   - File sync tools creating conflict copies with unusual extensions
-level: high
+level: critical

--- a/tuning/changelog/quality-review-2026-03-24.md
+++ b/tuning/changelog/quality-review-2026-03-24.md
@@ -1,0 +1,73 @@
+# Quality Review — 2026-03-24
+
+## Duplicate Pair: T1543.003 vs T1569.002
+
+**Files:**
+- `detections/persistence/t1543_003.yml` — Service Creation with Suspicious Binary Path
+- `detections/execution/t1569_002.yml` — sc.exe Service with Suspicious Binary Path
+
+**Overlap:** Both rules detect `sc.exe create` with a binary path in a writable directory
+(ProgramData, Temp, AppData, etc.). Both share the same core logic pattern and will
+co-fire on every Fawkes `service` command, producing duplicate alerts.
+
+**Differences:**
+- T1543.003 additionally detects `sc.exe config` and `sc.exe start` from writable paths
+- T1543.003 includes `%APPDATA%`, `%TEMP%`, `%USERPROFILE%` environment variable patterns
+- T1569.002 has a slightly tighter filter_legitimate block
+
+**Decision:** Keep both deployed. T1543.003 maps to persistence (creating the service),
+T1569.002 maps to execution (starting the service). They serve different MITRE tactic
+attribution even though the trigger events overlap. Analysts should expect co-firing
+and may want to suppress T1569.002 when T1543.003 fires on the same event.
+
+**Action needed:** Add `related` fields cross-referencing each other in a future PR.
+
+---
+
+## Overlapping LSASS Access Codes: T1003.001 vs T1134.001
+
+**Files:**
+- `detections/credential_access/t1003_001.yml` — LSASS Credential Dumping
+- `detections/credential_access/t1134_001_lsass_token_theft.yml` — LSASS Token Theft
+
+**Overlap:** All 6 GrantedAccess codes in T1134.001 also appear in T1003.001:
+`0x0040`, `0x1FFFFF`, `0x1010`, `0x1410`, `0x1438`, `0x143a`
+
+**Impact:** Every token theft access to LSASS fires both rules.
+
+**Recommended separation:**
+- T1134.001 (token theft): focus on `0x0040` (PROCESS_DUP_HANDLE) — the token-specific code
+- T1003.001 (credential dump): keep memory-read codes (`0x1F0FFF`, `0x1F1FFF`, `0x100000`)
+- Shared codes (`0x1010`, `0x1410`, `0x1438`, `0x143a`): leave in both but document expected co-fire
+
+**Action needed:** Refine GrantedAccess split in a future tuning PR.
+
+---
+
+## Severity Recalibration (this PR)
+
+| Rule | Before | After | Rationale |
+|------|--------|-------|-----------|
+| T1190 (webserver shell) | high | critical | High-fidelity initial access indicator |
+| T1486 (ransomware ext) | high | critical | Matches threshold companion; first encrypt signal |
+| T1082 (systeminfo) | high | medium | Single discovery command, common in admin workflows |
+| T1046 (port scan) | high | medium | Leading indicator, not high-severity standalone |
+
+---
+
+## ECS Field Name Corrections (this PR)
+
+4 rules converted from Sysmon XML to ECS field names:
+- T1059.003, T1082, T1190, T1204.002
+
+All used `Image`, `CommandLine`, `ParentImage`, `User` instead of
+`process.executable`, `process.command_line`, `process.parent.executable`, `user.name`.
+
+---
+
+## Missing logsource.category Added (this PR)
+
+3 rules had `product: windows` but no `category`:
+- T1003.001: added `category: process_access`
+- T1021.001: added `category: process_creation`
+- T1027.001: added `category: process_creation`


### PR DESCRIPTION
## Summary\n\nPortfolio-wide quality audit identified systemic issues across 10 detection rules. This PR fixes the highest-impact problems:\n\n- **ECS field names**: 4 rules (T1059.003, T1082, T1190, T1204.002) used Sysmon XML field names (`Image`, `CommandLine`, `ParentImage`, `User`) instead of ECS (`process.executable`, `process.command_line`, `process.parent.executable`, `user.name`). These would fail sigma-cli transpilation with the `ecs_windows` pipeline.\n- **Missing logsource.category**: 3 rules (T1003.001, T1021.001, T1027.001) had `product: windows` but no `category` field, which sigma-cli needs for field mapping.\n- **Severity recalibration**: 81% of rules were `high` severity, making triage impossible. Adjusted: T1190 high->critical (webserver shell), T1486 high->critical (ransomware), T1082 high->medium (systeminfo), T1046 high->medium (port scan).\n- **Duplicate documentation**: Documented T1543.003 vs T1569.002 co-firing and T1003.001 vs T1134.001 overlapping GrantedAccess codes.\n\n## Files Changed\n\n- 4 detection rules: ECS field name conversion\n- 3 detection rules: added logsource.category\n- 2 detection rules: severity recalibration\n- 1 new changelog: `tuning/changelog/quality-review-2026-03-24.md`\n\n## Test plan\n\n- [ ] Verify sigma-cli transpilation succeeds for all 4 ECS-fixed rules\n- [ ] Re-validate T1059.003, T1082, T1190, T1204.002 against ES (F1 scores may improve)\n- [ ] Confirm severity changes render correctly in Kibana alert triage view\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"