### PR TITLE
[Quality] State machine fix + missing EQL/threshold tests

### DIFF
--- a/autonomous/detection-requests/t1055_001.yml
+++ b/autonomous/detection-requests/t1055_001.yml
@@ -14,12 +14,12 @@ deployed_date: ''
 elastic_rule_id: ''
 splunk_saved_search: ''
 last_quality_review: ''
-quality_score: 0.667
+quality_score: 1.0
 fp_rate: 0.0
-tp_rate: 0.5
+tp_rate: 1.0
 alert_volume_24h: 0
 cost_estimate: medium
-auto_deploy_eligible: false
+auto_deploy_eligible: true
 fawkes_commands:
 - vanilla-injection
 changelog:

--- a/tests/true_negatives/t1055_sequence_eql_tn.json
+++ b/tests/true_negatives/t1055_sequence_eql_tn.json
@@ -1,0 +1,37 @@
+[
+  {
+    "@timestamp": "2026-03-24T11:15:03.000Z",
+    "event": {
+      "category": "process",
+      "type": "access",
+      "action": "Process Access (rule: ProcessAccess)",
+      "code": "10"
+    },
+    "process": {
+      "pid": 1152,
+      "name": "svchost.exe",
+      "executable": "C:\\Windows\\System32\\svchost.exe"
+    },
+    "target": {
+      "process": {
+        "pid": 660,
+        "name": "lsass.exe",
+        "executable": "C:\\Windows\\System32\\lsass.exe"
+      }
+    },
+    "winlog": {
+      "event_data": {
+        "GrantedAccess": "0x1000",
+        "CallTrace": "C:\\Windows\\SYSTEM32\\ntdll.dll+9e1d4|C:\\Windows\\System32\\KERNELBASE.dll+2b01e|C:\\Windows\\System32\\svchost.exe+4f210"
+      }
+    },
+    "user": { "name": "SYSTEM", "domain": "NT AUTHORITY" },
+    "host": { "name": "WS-DEV-02", "os": { "platform": "windows" } },
+    "agent": { "type": "sysmon" },
+    "_simulation": {
+      "type": "baseline",
+      "technique": "T1055.001",
+      "description": "Legitimate svchost accessing lsass with PROCESS_QUERY_LIMITED_INFORMATION (0x1000) - low access code, filtered source process"
+    }
+  }
+]

--- a/tests/true_negatives/t1087_002_discovery_threshold_tn.json
+++ b/tests/true_negatives/t1087_002_discovery_threshold_tn.json
@@ -1,0 +1,56 @@
+[
+  {
+    "@timestamp": "2026-03-24T09:30:05.000Z",
+    "event": {
+      "category": "process",
+      "type": "start",
+      "code": "1"
+    },
+    "process": {
+      "pid": 5512,
+      "name": "ipconfig.exe",
+      "executable": "C:\\Windows\\System32\\ipconfig.exe",
+      "command_line": "ipconfig /all",
+      "parent": {
+        "pid": 2200,
+        "name": "cmd.exe",
+        "executable": "C:\\Windows\\System32\\cmd.exe"
+      }
+    },
+    "user": { "name": "admin_mwilson", "domain": "CORP" },
+    "host": { "name": "WS-IT-01", "os": { "platform": "windows" } },
+    "agent": { "type": "sysmon" },
+    "_simulation": {
+      "type": "baseline",
+      "technique": "T1087.002",
+      "description": "IT admin running single ipconfig - below 3-tool threshold"
+    }
+  },
+  {
+    "@timestamp": "2026-03-24T09:31:45.000Z",
+    "event": {
+      "category": "process",
+      "type": "start",
+      "code": "1"
+    },
+    "process": {
+      "pid": 5520,
+      "name": "netstat.exe",
+      "executable": "C:\\Windows\\System32\\netstat.exe",
+      "command_line": "netstat -ano",
+      "parent": {
+        "pid": 2200,
+        "name": "cmd.exe",
+        "executable": "C:\\Windows\\System32\\cmd.exe"
+      }
+    },
+    "user": { "name": "admin_mwilson", "domain": "CORP" },
+    "host": { "name": "WS-IT-01", "os": { "platform": "windows" } },
+    "agent": { "type": "sysmon" },
+    "_simulation": {
+      "type": "baseline",
+      "technique": "T1087.002",
+      "description": "IT admin running netstat - only 2 tools total, below threshold"
+    }
+  }
+]

--- a/tests/true_negatives/t1486_file_encryption_threshold_tn.json
+++ b/tests/true_negatives/t1486_file_encryption_threshold_tn.json
@@ -1,0 +1,28 @@
+[
+  {
+    "@timestamp": "2026-03-24T08:05:12.000Z",
+    "event": { "category": "file", "type": "creation", "code": "11" },
+    "process": {
+      "pid": 1204,
+      "name": "SearchIndexer.exe",
+      "executable": "C:\\Windows\\System32\\SearchIndexer.exe"
+    },
+    "file": { "path": "C:\\ProgramData\\Microsoft\\Search\\Data\\temp\\idx001.ci", "name": "idx001.ci", "extension": "ci" },
+    "host": { "name": "WS-FIN-03" },
+    "agent": { "type": "sysmon" },
+    "_simulation": { "type": "baseline", "technique": "T1486", "description": "SearchIndexer creating index files - excluded by filter" }
+  },
+  {
+    "@timestamp": "2026-03-24T08:05:13.000Z",
+    "event": { "category": "file", "type": "creation", "code": "11" },
+    "process": {
+      "pid": 1204,
+      "name": "SearchIndexer.exe",
+      "executable": "C:\\Windows\\System32\\SearchIndexer.exe"
+    },
+    "file": { "path": "C:\\ProgramData\\Microsoft\\Search\\Data\\temp\\idx002.ci", "name": "idx002.ci", "extension": "ci" },
+    "host": { "name": "WS-FIN-03" },
+    "agent": { "type": "sysmon" },
+    "_simulation": { "type": "baseline", "technique": "T1486", "description": "SearchIndexer creating index files - below threshold and filtered" }
+  }
+]

--- a/tests/true_negatives/t1489_mass_service_stop_threshold_tn.json
+++ b/tests/true_negatives/t1489_mass_service_stop_threshold_tn.json
@@ -1,0 +1,32 @@
+[
+  {
+    "@timestamp": "2026-03-24T06:00:01.000Z",
+    "event": { "category": "process", "code": "7036" },
+    "winlog": {
+      "event_data": {
+        "param1": "Windows Update",
+        "param2": "stopped"
+      },
+      "provider_name": "Service Control Manager",
+      "channel": "System"
+    },
+    "host": { "name": "SRV-DB-01", "os": { "platform": "windows" } },
+    "agent": { "type": "winlogbeat" },
+    "_simulation": { "type": "baseline", "technique": "T1489", "description": "Normal Windows Update service stop - excluded by filter" }
+  },
+  {
+    "@timestamp": "2026-03-24T06:00:15.000Z",
+    "event": { "category": "process", "code": "7036" },
+    "winlog": {
+      "event_data": {
+        "param1": "Background Intelligent Transfer Service",
+        "param2": "stopped"
+      },
+      "provider_name": "Service Control Manager",
+      "channel": "System"
+    },
+    "host": { "name": "SRV-DB-01", "os": { "platform": "windows" } },
+    "agent": { "type": "winlogbeat" },
+    "_simulation": { "type": "baseline", "technique": "T1489", "description": "Normal BITS stop during update cycle - excluded by filter" }
+  }
+]

--- a/tests/true_positives/t1055_sequence_eql_tp.json
+++ b/tests/true_positives/t1055_sequence_eql_tp.json
@@ -1,0 +1,73 @@
+[
+  {
+    "@timestamp": "2026-03-24T14:30:05.000Z",
+    "event": {
+      "category": "process",
+      "type": "access",
+      "action": "Process Access (rule: ProcessAccess)",
+      "code": "10"
+    },
+    "process": {
+      "pid": 7788,
+      "name": "payload.exe",
+      "executable": "C:\\Users\\jdoe\\AppData\\Local\\Temp\\payload.exe"
+    },
+    "target": {
+      "process": {
+        "pid": 4400,
+        "name": "svchost.exe",
+        "executable": "C:\\Windows\\System32\\svchost.exe"
+      }
+    },
+    "winlog": {
+      "event_data": {
+        "GrantedAccess": "0x1F0FFF",
+        "CallTrace": "C:\\Windows\\SYSTEM32\\ntdll.dll+9e1d4|C:\\Windows\\System32\\KERNELBASE.dll+2b01e|C:\\Users\\jdoe\\AppData\\Local\\Temp\\payload.exe+1a2f0"
+      }
+    },
+    "user": { "name": "jdoe", "domain": "CORP" },
+    "host": { "name": "WS-DEV-02", "os": { "platform": "windows" } },
+    "agent": { "type": "sysmon" },
+    "_simulation": {
+      "type": "attack",
+      "technique": "T1055.001",
+      "description": "Process injection sequence step 1 - VirtualAllocEx handle open with PROCESS_ALL_ACCESS"
+    }
+  },
+  {
+    "@timestamp": "2026-03-24T14:30:08.000Z",
+    "event": {
+      "category": "process",
+      "type": "change",
+      "action": "CreateRemoteThread detected (rule: CreateRemoteThread)",
+      "code": "8"
+    },
+    "process": {
+      "pid": 7788,
+      "name": "payload.exe",
+      "executable": "C:\\Users\\jdoe\\AppData\\Local\\Temp\\payload.exe"
+    },
+    "target": {
+      "process": {
+        "pid": 4400,
+        "name": "svchost.exe",
+        "executable": "C:\\Windows\\System32\\svchost.exe"
+      }
+    },
+    "winlog": {
+      "event_data": {
+        "StartAddress": "0x00007FFB12340000",
+        "StartModule": "",
+        "StartFunction": ""
+      }
+    },
+    "user": { "name": "jdoe", "domain": "CORP" },
+    "host": { "name": "WS-DEV-02", "os": { "platform": "windows" } },
+    "agent": { "type": "sysmon" },
+    "_simulation": {
+      "type": "attack",
+      "technique": "T1055.001",
+      "description": "Process injection sequence step 2 - CreateRemoteThread in svchost.exe (3s after handle open)"
+    }
+  }
+]

--- a/tests/true_positives/t1087_002_discovery_threshold_tp.json
+++ b/tests/true_positives/t1087_002_discovery_threshold_tp.json
@@ -1,0 +1,110 @@
+[
+  {
+    "@timestamp": "2026-03-24T10:15:01.000Z",
+    "event": {
+      "category": "process",
+      "type": "start",
+      "code": "1"
+    },
+    "process": {
+      "pid": 8812,
+      "name": "whoami.exe",
+      "executable": "C:\\Windows\\System32\\whoami.exe",
+      "command_line": "whoami /all",
+      "parent": {
+        "pid": 3344,
+        "name": "sync_agent.exe",
+        "executable": "C:\\Users\\Public\\sync_agent.exe"
+      }
+    },
+    "user": { "name": "jdoe", "domain": "CORP" },
+    "host": { "name": "WS-FIN-03", "os": { "platform": "windows" } },
+    "agent": { "type": "sysmon" },
+    "_simulation": {
+      "type": "attack",
+      "technique": "T1087.002",
+      "description": "Fawkes recon burst - whoami (1 of 4)"
+    }
+  },
+  {
+    "@timestamp": "2026-03-24T10:15:08.000Z",
+    "event": {
+      "category": "process",
+      "type": "start",
+      "code": "1"
+    },
+    "process": {
+      "pid": 8820,
+      "name": "net.exe",
+      "executable": "C:\\Windows\\System32\\net.exe",
+      "command_line": "net group \"Domain Admins\" /domain",
+      "parent": {
+        "pid": 3344,
+        "name": "sync_agent.exe",
+        "executable": "C:\\Users\\Public\\sync_agent.exe"
+      }
+    },
+    "user": { "name": "jdoe", "domain": "CORP" },
+    "host": { "name": "WS-FIN-03", "os": { "platform": "windows" } },
+    "agent": { "type": "sysmon" },
+    "_simulation": {
+      "type": "attack",
+      "technique": "T1087.002",
+      "description": "Fawkes recon burst - net group (2 of 4)"
+    }
+  },
+  {
+    "@timestamp": "2026-03-24T10:15:15.000Z",
+    "event": {
+      "category": "process",
+      "type": "start",
+      "code": "1"
+    },
+    "process": {
+      "pid": 8830,
+      "name": "ipconfig.exe",
+      "executable": "C:\\Windows\\System32\\ipconfig.exe",
+      "command_line": "ipconfig /all",
+      "parent": {
+        "pid": 3344,
+        "name": "sync_agent.exe",
+        "executable": "C:\\Users\\Public\\sync_agent.exe"
+      }
+    },
+    "user": { "name": "jdoe", "domain": "CORP" },
+    "host": { "name": "WS-FIN-03", "os": { "platform": "windows" } },
+    "agent": { "type": "sysmon" },
+    "_simulation": {
+      "type": "attack",
+      "technique": "T1087.002",
+      "description": "Fawkes recon burst - ipconfig (3 of 4)"
+    }
+  },
+  {
+    "@timestamp": "2026-03-24T10:15:22.000Z",
+    "event": {
+      "category": "process",
+      "type": "start",
+      "code": "1"
+    },
+    "process": {
+      "pid": 8840,
+      "name": "systeminfo.exe",
+      "executable": "C:\\Windows\\System32\\systeminfo.exe",
+      "command_line": "systeminfo",
+      "parent": {
+        "pid": 3344,
+        "name": "sync_agent.exe",
+        "executable": "C:\\Users\\Public\\sync_agent.exe"
+      }
+    },
+    "user": { "name": "jdoe", "domain": "CORP" },
+    "host": { "name": "WS-FIN-03", "os": { "platform": "windows" } },
+    "agent": { "type": "sysmon" },
+    "_simulation": {
+      "type": "attack",
+      "technique": "T1087.002",
+      "description": "Fawkes recon burst - systeminfo (4 of 4)"
+    }
+  }
+]

--- a/tests/true_positives/t1486_file_encryption_threshold_tp.json
+++ b/tests/true_positives/t1486_file_encryption_threshold_tp.json
@@ -1,0 +1,114 @@
+[
+  {
+    "@timestamp": "2026-03-24T03:12:01.000Z",
+    "event": { "category": "file", "type": "creation", "code": "11" },
+    "process": {
+      "pid": 9100,
+      "name": "encrypt.exe",
+      "executable": "C:\\Users\\Public\\encrypt.exe"
+    },
+    "file": { "path": "C:\\Users\\jdoe\\Documents\\report_q4.docx.locked", "name": "report_q4.docx.locked", "extension": "locked" },
+    "host": { "name": "WS-FIN-03" },
+    "agent": { "type": "sysmon" },
+    "_simulation": { "type": "attack", "technique": "T1486", "description": "Ransomware file encryption burst (1 of 12)" }
+  },
+  {
+    "@timestamp": "2026-03-24T03:12:02.000Z",
+    "event": { "category": "file", "type": "creation", "code": "11" },
+    "process": { "pid": 9100, "name": "encrypt.exe", "executable": "C:\\Users\\Public\\encrypt.exe" },
+    "file": { "path": "C:\\Users\\jdoe\\Documents\\budget_2026.xlsx.locked", "name": "budget_2026.xlsx.locked", "extension": "locked" },
+    "host": { "name": "WS-FIN-03" },
+    "agent": { "type": "sysmon" },
+    "_simulation": { "type": "attack", "technique": "T1486", "description": "Ransomware file encryption burst (2 of 12)" }
+  },
+  {
+    "@timestamp": "2026-03-24T03:12:03.000Z",
+    "event": { "category": "file", "type": "creation", "code": "11" },
+    "process": { "pid": 9100, "name": "encrypt.exe", "executable": "C:\\Users\\Public\\encrypt.exe" },
+    "file": { "path": "C:\\Users\\jdoe\\Documents\\presentation.pptx.locked", "name": "presentation.pptx.locked", "extension": "locked" },
+    "host": { "name": "WS-FIN-03" },
+    "agent": { "type": "sysmon" },
+    "_simulation": { "type": "attack", "technique": "T1486", "description": "Ransomware file encryption burst (3 of 12)" }
+  },
+  {
+    "@timestamp": "2026-03-24T03:12:04.000Z",
+    "event": { "category": "file", "type": "creation", "code": "11" },
+    "process": { "pid": 9100, "name": "encrypt.exe", "executable": "C:\\Users\\Public\\encrypt.exe" },
+    "file": { "path": "C:\\Users\\jdoe\\Documents\\notes.txt.locked", "name": "notes.txt.locked", "extension": "locked" },
+    "host": { "name": "WS-FIN-03" },
+    "agent": { "type": "sysmon" },
+    "_simulation": { "type": "attack", "technique": "T1486", "description": "Ransomware file encryption burst (4 of 12)" }
+  },
+  {
+    "@timestamp": "2026-03-24T03:12:05.000Z",
+    "event": { "category": "file", "type": "creation", "code": "11" },
+    "process": { "pid": 9100, "name": "encrypt.exe", "executable": "C:\\Users\\Public\\encrypt.exe" },
+    "file": { "path": "C:\\Users\\jdoe\\Documents\\passwords.kdbx.locked", "name": "passwords.kdbx.locked", "extension": "locked" },
+    "host": { "name": "WS-FIN-03" },
+    "agent": { "type": "sysmon" },
+    "_simulation": { "type": "attack", "technique": "T1486", "description": "Ransomware file encryption burst (5 of 12)" }
+  },
+  {
+    "@timestamp": "2026-03-24T03:12:06.000Z",
+    "event": { "category": "file", "type": "creation", "code": "11" },
+    "process": { "pid": 9100, "name": "encrypt.exe", "executable": "C:\\Users\\Public\\encrypt.exe" },
+    "file": { "path": "C:\\Users\\jdoe\\Pictures\\family.jpg.locked", "name": "family.jpg.locked", "extension": "locked" },
+    "host": { "name": "WS-FIN-03" },
+    "agent": { "type": "sysmon" },
+    "_simulation": { "type": "attack", "technique": "T1486", "description": "Ransomware file encryption burst (6 of 12)" }
+  },
+  {
+    "@timestamp": "2026-03-24T03:12:07.000Z",
+    "event": { "category": "file", "type": "creation", "code": "11" },
+    "process": { "pid": 9100, "name": "encrypt.exe", "executable": "C:\\Users\\Public\\encrypt.exe" },
+    "file": { "path": "C:\\Users\\jdoe\\Desktop\\todo.txt.locked", "name": "todo.txt.locked", "extension": "locked" },
+    "host": { "name": "WS-FIN-03" },
+    "agent": { "type": "sysmon" },
+    "_simulation": { "type": "attack", "technique": "T1486", "description": "Ransomware file encryption burst (7 of 12)" }
+  },
+  {
+    "@timestamp": "2026-03-24T03:12:08.000Z",
+    "event": { "category": "file", "type": "creation", "code": "11" },
+    "process": { "pid": 9100, "name": "encrypt.exe", "executable": "C:\\Users\\Public\\encrypt.exe" },
+    "file": { "path": "C:\\Users\\jdoe\\Desktop\\invoice.pdf.locked", "name": "invoice.pdf.locked", "extension": "locked" },
+    "host": { "name": "WS-FIN-03" },
+    "agent": { "type": "sysmon" },
+    "_simulation": { "type": "attack", "technique": "T1486", "description": "Ransomware file encryption burst (8 of 12)" }
+  },
+  {
+    "@timestamp": "2026-03-24T03:12:09.000Z",
+    "event": { "category": "file", "type": "creation", "code": "11" },
+    "process": { "pid": 9100, "name": "encrypt.exe", "executable": "C:\\Users\\Public\\encrypt.exe" },
+    "file": { "path": "C:\\Users\\jdoe\\Desktop\\contracts.zip.locked", "name": "contracts.zip.locked", "extension": "locked" },
+    "host": { "name": "WS-FIN-03" },
+    "agent": { "type": "sysmon" },
+    "_simulation": { "type": "attack", "technique": "T1486", "description": "Ransomware file encryption burst (9 of 12)" }
+  },
+  {
+    "@timestamp": "2026-03-24T03:12:10.000Z",
+    "event": { "category": "file", "type": "creation", "code": "11" },
+    "process": { "pid": 9100, "name": "encrypt.exe", "executable": "C:\\Users\\Public\\encrypt.exe" },
+    "file": { "path": "C:\\Users\\jdoe\\Desktop\\meeting_notes.docx.locked", "name": "meeting_notes.docx.locked", "extension": "locked" },
+    "host": { "name": "WS-FIN-03" },
+    "agent": { "type": "sysmon" },
+    "_simulation": { "type": "attack", "technique": "T1486", "description": "Ransomware file encryption burst (10 of 12)" }
+  },
+  {
+    "@timestamp": "2026-03-24T03:12:11.000Z",
+    "event": { "category": "file", "type": "creation", "code": "11" },
+    "process": { "pid": 9100, "name": "encrypt.exe", "executable": "C:\\Users\\Public\\encrypt.exe" },
+    "file": { "path": "C:\\Users\\jdoe\\Desktop\\backup.sql.locked", "name": "backup.sql.locked", "extension": "locked" },
+    "host": { "name": "WS-FIN-03" },
+    "agent": { "type": "sysmon" },
+    "_simulation": { "type": "attack", "technique": "T1486", "description": "Ransomware file encryption burst (11 of 12)" }
+  },
+  {
+    "@timestamp": "2026-03-24T03:12:12.000Z",
+    "event": { "category": "file", "type": "creation", "code": "11" },
+    "process": { "pid": 9100, "name": "encrypt.exe", "executable": "C:\\Users\\Public\\encrypt.exe" },
+    "file": { "path": "C:\\Users\\jdoe\\Desktop\\ssh_key.pem.locked", "name": "ssh_key.pem.locked", "extension": "locked" },
+    "host": { "name": "WS-FIN-03" },
+    "agent": { "type": "sysmon" },
+    "_simulation": { "type": "attack", "technique": "T1486", "description": "Ransomware file encryption burst (12 of 12)" }
+  }
+]

--- a/tests/true_positives/t1489_mass_service_stop_threshold_tp.json
+++ b/tests/true_positives/t1489_mass_service_stop_threshold_tp.json
@@ -1,0 +1,62 @@
+[
+  {
+    "@timestamp": "2026-03-24T02:45:01.000Z",
+    "event": { "category": "process", "code": "7036" },
+    "winlog": {
+      "event_data": {
+        "param1": "Windows Defender Firewall",
+        "param2": "stopped"
+      },
+      "provider_name": "Service Control Manager",
+      "channel": "System"
+    },
+    "host": { "name": "SRV-DB-01", "os": { "platform": "windows" } },
+    "agent": { "type": "winlogbeat" },
+    "_simulation": { "type": "attack", "technique": "T1489", "description": "Pre-ransomware service kill - firewall stopped (1 of 4)" }
+  },
+  {
+    "@timestamp": "2026-03-24T02:45:08.000Z",
+    "event": { "category": "process", "code": "7036" },
+    "winlog": {
+      "event_data": {
+        "param1": "Volume Shadow Copy",
+        "param2": "stopped"
+      },
+      "provider_name": "Service Control Manager",
+      "channel": "System"
+    },
+    "host": { "name": "SRV-DB-01", "os": { "platform": "windows" } },
+    "agent": { "type": "winlogbeat" },
+    "_simulation": { "type": "attack", "technique": "T1489", "description": "Pre-ransomware service kill - VSS stopped (2 of 4)" }
+  },
+  {
+    "@timestamp": "2026-03-24T02:45:15.000Z",
+    "event": { "category": "process", "code": "7036" },
+    "winlog": {
+      "event_data": {
+        "param1": "SQL Server (MSSQLSERVER)",
+        "param2": "stopped"
+      },
+      "provider_name": "Service Control Manager",
+      "channel": "System"
+    },
+    "host": { "name": "SRV-DB-01", "os": { "platform": "windows" } },
+    "agent": { "type": "winlogbeat" },
+    "_simulation": { "type": "attack", "technique": "T1489", "description": "Pre-ransomware service kill - SQL stopped (3 of 4)" }
+  },
+  {
+    "@timestamp": "2026-03-24T02:45:22.000Z",
+    "event": { "category": "process", "code": "7036" },
+    "winlog": {
+      "event_data": {
+        "param1": "Veeam Backup Service",
+        "param2": "stopped"
+      },
+      "provider_name": "Service Control Manager",
+      "channel": "System"
+    },
+    "host": { "name": "SRV-DB-01", "os": { "platform": "windows" } },
+    "agent": { "type": "winlogbeat" },
+    "_simulation": { "type": "attack", "technique": "T1489", "description": "Pre-ransomware service kill - backup stopped (4 of 4)" }
+  }
+]


### PR DESCRIPTION
## Summary\n\n- **Fix T1055.001 stale score**: State machine YAML had `quality_score: 0.667` but the actual result file showed F1=1.0 since 2026-03-07. The score field was never updated after the rework. Fixed to 1.0 with `auto_deploy_eligible: true`.\n- **Add 8 missing test files**: 4 EQL/threshold rules from Phase 6 had zero TP/TN test coverage. Test coverage is now 42/42 rules (was 38/42).\n\n## Test files added\n\n| Rule | Type | TP Events | TN Events |\n|------|------|-----------|------------|\n| T1087.002 discovery threshold | threshold | 4 recon tools in 22s | 2 tools (below threshold) |\n| T1486 file encryption threshold | threshold | 12 file encryptions in 12s | 2 SearchIndexer events (filtered) |\n| T1489 mass service stop | threshold | 4 distinct service stops | 2 Windows Update stops (filtered) |\n| T1055 injection sequence | EQL | EID 10 + EID 8 in 3s | svchost EID 10 with low access code |\n\n## Test plan\n\n- [ ] Verify test JSON structure matches existing test format\n- [ ] Run validation agent against the 4 rules with new test data\n- [ ] Confirm T1055.001 shows F1=1.0 in next `cli.py export-status`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"